### PR TITLE
Feat: add support for multiple CAPTCHA types with different configurations

### DIFF
--- a/samples/AspNetCore3_1/Controllers/CaptchaController.cs
+++ b/samples/AspNetCore3_1/Controllers/CaptchaController.cs
@@ -25,6 +25,13 @@ public class CaptchaController : Controller
         return Ok(challengeTokenInfo);
     }
 
+    [HttpPost("{type}/challenge")]
+    public async Task<IActionResult> Challenge(string type, CancellationToken cancellationToken = default)
+    {
+        var challengeTokenInfo = await _captchaService.CreateChallengeAsync(type, cancellationToken).ConfigureAwait(false);
+        return Ok(challengeTokenInfo);
+    }
+
     [HttpPost("redeem")]
     public async Task<IActionResult> Redeem([FromBody] ChallengeSolution challengeSolution, CancellationToken cancellationToken = default)
     {
@@ -34,6 +41,18 @@ public class CaptchaController : Controller
         }
 
         var result = await _captchaService.RedeemChallengeAsync(challengeSolution, cancellationToken).ConfigureAwait(false);
+        return Ok(result);
+    }
+
+    [HttpPost("{type}/redeem")]
+    public async Task<IActionResult> Redeem(string type, [FromBody] ChallengeSolution challengeSolution, CancellationToken cancellationToken = default)
+    {
+        if (challengeSolution == null)
+        {
+            return BadRequest("Invalid request");
+        }
+
+        var result = await _captchaService.RedeemChallengeAsync(type, challengeSolution, cancellationToken).ConfigureAwait(false);
         return Ok(result);
     }
 

--- a/samples/AspNetCore3_1/Pages/Index.cshtml
+++ b/samples/AspNetCore3_1/Pages/Index.cshtml
@@ -4,10 +4,17 @@
     ViewData["Title"] = "Home page";
 }
 
-<div class="text-center">
+@* <div class="text-center">
     <h1 class="display-4">Welcome</h1>
-    <p>Learn about <a href="https://docs.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
+    <p>Learn about <a href="https://learn.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
+</div> *@
+
+<div>
+    <label class="form-label">Default CAPTCHA (data-cap-api-endpoint="/api/captcha/"), Difficulty = 4</label>
     <cap-widget id="cap" data-cap-api-endpoint="/api/captcha/"></cap-widget>
+
+    <label class="form-label mt-4">Login Type CAPTCHA (data-cap-api-endpoint="/api/captcha/login/") , Difficulty = 5</label>
+    <cap-widget id="cap-login" data-cap-api-endpoint="/api/captcha/login/"></cap-widget>
 </div>
 
 <div class="container mt-5">
@@ -27,6 +34,12 @@
     document.addEventListener('DOMContentLoaded', function () {
            const widget = document.querySelector("#cap");
            widget.addEventListener("solve", function (e) {
+               const token = e.detail.token;
+               document.getElementById("tokenInput").value = token;
+           });
+
+           const loginWidget = document.querySelector("#cap-login");
+           loginWidget.addEventListener("solve", function (e) {
                const token = e.detail.token;
                document.getElementById("tokenInput").value = token;
            });

--- a/samples/AspNetCore3_1/Startup.cs
+++ b/samples/AspNetCore3_1/Startup.cs
@@ -1,8 +1,10 @@
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using PowCapServer;
 
 namespace AspNetCore3_1;
 
@@ -19,7 +21,13 @@ public class Startup
     public void ConfigureServices(IServiceCollection services)
     {
         services.AddRazorPages();
-        services.AddPowCapServer();
+        services.AddPowCapServer(options =>
+        {
+            options.TypeConfigs = new Dictionary<string, PowCapConfig>
+            {
+                ["login"] = new PowCapConfig { ChallengeDifficulty = 5 }
+            };
+        });
     }
 
     // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/samples/WebApplication1/Pages/Index.cshtml
+++ b/samples/WebApplication1/Pages/Index.cshtml
@@ -4,11 +4,17 @@
     ViewData["Title"] = "Home page";
 }
 
-<div class="text-center">
+@* <div class="text-center">
     <h1 class="display-4">Welcome</h1>
     <p>Learn about <a href="https://learn.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
+</div> *@
 
+<div>
+    <label class="form-label">Default CAPTCHA (data-cap-api-endpoint="/api/captcha/"), Difficulty = 4</label>
     <cap-widget id="cap" data-cap-api-endpoint="/api/captcha/"></cap-widget>
+
+    <label class="form-label mt-4">Login Type CAPTCHA (data-cap-api-endpoint="/api/captcha/login/") , Difficulty = 5</label>
+    <cap-widget id="cap-login" data-cap-api-endpoint="/api/captcha/login/"></cap-widget>
 </div>
 
 <div class="container mt-5">
@@ -28,6 +34,12 @@
     document.addEventListener('DOMContentLoaded', function () {
            const widget = document.querySelector("#cap");
            widget.addEventListener("solve", function (e) {
+               const token = e.detail.token;
+               document.getElementById("tokenInput").value = token;
+           });
+
+           const loginWidget = document.querySelector("#cap-login");
+           loginWidget.addEventListener("solve", function (e) {
                const token = e.detail.token;
                document.getElementById("tokenInput").value = token;
            });

--- a/samples/WebApplication1/Program.cs
+++ b/samples/WebApplication1/Program.cs
@@ -1,10 +1,17 @@
+using PowCapServer;
 using PowCapServer.Abstractions;
 
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 builder.Services.AddRazorPages();
-builder.Services.AddPowCapServer();
+builder.Services.AddPowCapServer(options =>
+{
+    options.TypeConfigs = new Dictionary<string, PowCapConfig>
+    {
+        ["login"] = new PowCapConfig { ChallengeDifficulty = 5 }
+    };
+});
 //builder.Services.AddStackExchangeRedisCache(options =>
 //{
 //    options.Configuration = "localhost:6379"; // Redis server configuration

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Copyright>Amos Huang</Copyright>
     <Authors>Amos Huang</Authors>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageProjectUrl>https://github.com/izanhzh/pow-cap-server</PackageProjectUrl>

--- a/src/PowCapServer.Core/Abstractions/ICaptchaService.cs
+++ b/src/PowCapServer.Core/Abstractions/ICaptchaService.cs
@@ -8,7 +8,11 @@ public interface ICaptchaService
 {
     Task<ChallengeTokenInfo> CreateChallengeAsync(CancellationToken cancellationToken = default);
 
+    Task<ChallengeTokenInfo> CreateChallengeAsync(string? type, CancellationToken cancellationToken = default);
+
     Task<RedeemChallengeResult> RedeemChallengeAsync(ChallengeSolution challengeSolution, CancellationToken cancellationToken = default);
+
+    Task<RedeemChallengeResult> RedeemChallengeAsync(string? type, ChallengeSolution challengeSolution, CancellationToken cancellationToken = default);
 
     Task<bool> ValidateCaptchaTokenAsync(string captchaToken, CancellationToken cancellationToken = default);
 }

--- a/src/PowCapServer.Core/Microsoft/Extensions/DependencyInjection/PowCapServerServiceCollectionExtensions.cs
+++ b/src/PowCapServer.Core/Microsoft/Extensions/DependencyInjection/PowCapServerServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using PowCapServer;
 using PowCapServer.Abstractions;
 
@@ -6,25 +7,12 @@ namespace Microsoft.Extensions.DependencyInjection;
 
 public static class PowCapServerServiceCollectionExtensions
 {
-    public static IServiceCollection AddPowCapServer(this IServiceCollection services)
-    {
-        return services
-            .AddPowCapServer(options =>
-            {
-                options.ChallengeCount = 50;
-                options.ChallengeSize = 32;
-                options.ChallengeDifficulty = 4;
-                options.ChallengeTokenExpiresMs = 600000;
-                options.CaptchaTokenExpiresMs = 1200000;
-            });
-    }
-
-    public static IServiceCollection AddPowCapServer(this IServiceCollection services, Action<PowCapServerOptions> options)
+    public static IServiceCollection AddPowCapServer(this IServiceCollection services, Action<PowCapServerOptions>? options = null)
     {
         services.AddDistributedMemoryCache();
-        services.AddSingleton<ICaptchaService, DefaultCaptchaService>();
-        services.AddSingleton<ICaptchaStore, DefaultCaptchaStore>();
-        services.Configure(options);
+        services.TryAddSingleton<ICaptchaService, DefaultCaptchaService>();
+        services.TryAddSingleton<ICaptchaStore, DefaultCaptchaStore>();
+        services.Configure<PowCapServerOptions>(opts => options?.Invoke(opts));
         return services;
     }
 }

--- a/src/PowCapServer.Core/PowCapConfig.cs
+++ b/src/PowCapServer.Core/PowCapConfig.cs
@@ -1,0 +1,29 @@
+namespace PowCapServer;
+
+public class PowCapConfig
+{
+    /// <summary>
+    /// Number of challenges to generate
+    /// </summary>
+    public int ChallengeCount { get; set; } = 50;
+
+    /// <summary>
+    /// Size of each challenge in bytes
+    /// </summary>
+    public int ChallengeSize { get; set; } = 32;
+
+    /// <summary>
+    /// Difficulty level of the challenge
+    /// </summary>
+    public int ChallengeDifficulty { get; set; } = 4;
+
+    /// <summary>
+    /// Time in milliseconds until the challenge token expires
+    /// </summary>
+    public long ChallengeTokenExpiresMs { get; set; } = 600000;
+
+    /// <summary>
+    /// Time in milliseconds until the captcha token expires
+    /// </summary>
+    public long CaptchaTokenExpiresMs { get; set; } = 1200000;
+}

--- a/src/PowCapServer.Core/PowCapServerOptions.cs
+++ b/src/PowCapServer.Core/PowCapServerOptions.cs
@@ -1,29 +1,30 @@
+using System.Collections.Generic;
+
 namespace PowCapServer;
 
 public class PowCapServerOptions
 {
     /// <summary>
-    /// Number of challenges to generate
+    /// Default configuration for not specified PoW Captcha types
     /// </summary>
-    public int ChallengeCount { get; set; }
+    public PowCapConfig Default { get; set; } = new PowCapConfig();
 
     /// <summary>
-    /// Size of each challenge in bytes
+    /// Dictionary of configurations for different types of PoW Captcha
     /// </summary>
-    public int ChallengeSize { get; set; }
+    public Dictionary<string, PowCapConfig>? TypeConfigs { get; set; }
 
     /// <summary>
-    /// Difficulty level of the challenge
+    /// Gets the configuration for a specific type of PoW Captcha.
     /// </summary>
-    public int ChallengeDifficulty { get; set; }
-
-    /// <summary>
-    /// Time in milliseconds until the challenge token expires
-    /// </summary>
-    public long ChallengeTokenExpiresMs { get; set; }
-
-    /// <summary>
-    /// Time in milliseconds until the captcha token expires
-    /// </summary>
-    public long CaptchaTokenExpiresMs { get; set; }
+    /// <param name="type"></param>
+    /// <returns></returns>
+    public PowCapConfig? GetPowCapConfig(string? type)
+    {
+        if (TypeConfigs == null || type == null || !TypeConfigs.TryGetValue(type, out var config))
+        {
+            return null;
+        }
+        return config;
+    }
 }


### PR DESCRIPTION
- Added documentation for CAPTCHA type feature allowing different configurations per type
- Updated usage examples to show how to configure default and type-specific CAPTCHA settings
- Documented endpoint patterns for type-specific CAPTCHA challenges and redemptions
- Added examples for frontend integration with different CAPTCHA types
- Enhanced feature list to include multiple CAPTCHA types support

This feature allows users to define different difficulty levels and expiration times for different types of CAPTCHAs (e.g., login, form submission) through separate endpoints.