### PR TITLE
Chore: rename parameter 'type' to 'useCase'

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ dotnet add package PowCapServer.AspNetCore
 
 
 ## 🧩 Features
-- ✅ Challenge generation (`/api/captcha/challenge` or `/api/captcha/{type}/challenge`)
-- ✅ Challenge redemption (`/api/captcha/redeem` or `/api/captcha/{type}/redeem`)
+- ✅ Challenge generation (`/api/captcha/challenge` or `/api/captcha/{useCase}/challenge`)
+- ✅ Challenge redemption (`/api/captcha/redeem` or `/api/captcha/{useCase}/redeem`)
 - ✅ Token-based CAPTCHA validation
 - ✅ Configurable difficulty, expiration times, and endpoint paths
 - ✅ Built-in token cleanup for expired challenges
@@ -36,15 +36,15 @@ dotnet add package PowCapServer.AspNetCore
 ```csharp
 builder.Services.AddPowCapServer(options =>
 {
-    // Default configuration for CAPTCHAs without specific type
+    // Default configuration for CAPTCHAs without specific use case
     options.Default.ChallengeCount = 1000;
     options.Default.ChallengeSize = 32;
     options.Default.ChallengeDifficulty = 4;
     options.Default.ChallengeTokenExpiresMs = 60000;
     options.Default.CaptchaTokenExpiresMs = 120000;
 
-    // Configuration for specific CAPTCHA types
-    options.TypeConfigs = new Dictionary<string, PowCapConfig>()
+    // Configuration for specific use case CAPTCHA
+    options.UseCaseConfigs = new Dictionary<string, PowCapConfig>()
     {
         ["login"] = new PowCapConfig
         {
@@ -75,9 +75,9 @@ app.MapPowCapServer();
 This will expose the following endpoints:
 
 - POST /api/captcha/challenge – Generate a new CAPTCHA challenge with default configuration.
-- POST /api/captcha/{type}/challenge – Generate a new CAPTCHA challenge with configuration specific to the type.
+- POST /api/captcha/{useCase}/challenge – Generate a new CAPTCHA challenge with configuration specific to the use case.
 - POST /api/captcha/redeem – Redeem a solved CAPTCHA challenge with default configuration.
-- POST /api/captcha/{type}/redeem – Redeem a solved CAPTCHA challenge with configuration specific to the type.
+- POST /api/captcha/{useCase}/redeem – Redeem a solved CAPTCHA challenge with configuration specific to the use case.
 
 
 ## 🗃️ Storage and Caching
@@ -113,7 +113,7 @@ For more information on available `IDistributedCache` implementations, please re
 ## 📐 Integration with Frontend
 please refer to the official documentation of [@cap.js/widget](https://capjs.js.org/guide/widget.html) for instructions on how to embed and configure the CAPTCHA widget in your web application.
 
-Example for default CAPTCHA type:
+Example for default CAPTCHA:
 
 ```html
 <script src="https://cdn.jsdelivr.net/npm/@cap.js/widget"></script>
@@ -121,7 +121,7 @@ Example for default CAPTCHA type:
 <cap-widget id="cap" data-cap-api-endpoint="/api/captcha/"></cap-widget>
 ```
 
-Example for specific CAPTCHA type (e.g. login):
+Example for specific use case CAPTCHA (e.g. login):
 ```html
 <script src="https://cdn.jsdelivr.net/npm/@cap.js/widget"></script>
 

--- a/pow-cap-server.sln
+++ b/pow-cap-server.sln
@@ -4,12 +4,16 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 VisualStudioVersion = 17.14.36221.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{02EA681E-C7D8-13C7-8484-4AC65E1B71E8}"
+	ProjectSection(SolutionItems) = preProject
+		src\Directory.Build.props = src\Directory.Build.props
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{0CE312F7-F4DD-4AD2-B8DD-160855E6D7D7}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8EC02BFE-5BBB-4C7A-BF61-CA5F3FAED286}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		Directory.Build.props = Directory.Build.props
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{AF9947EF-021F-4548-A92B-972141F1D8B5}"

--- a/samples/AspNetCore3_1/Controllers/CaptchaController.cs
+++ b/samples/AspNetCore3_1/Controllers/CaptchaController.cs
@@ -25,10 +25,10 @@ public class CaptchaController : Controller
         return Ok(challengeTokenInfo);
     }
 
-    [HttpPost("{type}/challenge")]
-    public async Task<IActionResult> Challenge(string type, CancellationToken cancellationToken = default)
+    [HttpPost("{useCase}/challenge")]
+    public async Task<IActionResult> Challenge(string useCase, CancellationToken cancellationToken = default)
     {
-        var challengeTokenInfo = await _captchaService.CreateChallengeAsync(type, cancellationToken).ConfigureAwait(false);
+        var challengeTokenInfo = await _captchaService.CreateChallengeAsync(useCase, cancellationToken).ConfigureAwait(false);
         return Ok(challengeTokenInfo);
     }
 
@@ -44,15 +44,15 @@ public class CaptchaController : Controller
         return Ok(result);
     }
 
-    [HttpPost("{type}/redeem")]
-    public async Task<IActionResult> Redeem(string type, [FromBody] ChallengeSolution challengeSolution, CancellationToken cancellationToken = default)
+    [HttpPost("{useCase}/redeem")]
+    public async Task<IActionResult> Redeem(string useCase, [FromBody] ChallengeSolution challengeSolution, CancellationToken cancellationToken = default)
     {
         if (challengeSolution == null)
         {
             return BadRequest("Invalid request");
         }
 
-        var result = await _captchaService.RedeemChallengeAsync(type, challengeSolution, cancellationToken).ConfigureAwait(false);
+        var result = await _captchaService.RedeemChallengeAsync(useCase, challengeSolution, cancellationToken).ConfigureAwait(false);
         return Ok(result);
     }
 

--- a/samples/AspNetCore3_1/Pages/Index.cshtml
+++ b/samples/AspNetCore3_1/Pages/Index.cshtml
@@ -13,7 +13,7 @@
     <label class="form-label">Default CAPTCHA (data-cap-api-endpoint="/api/captcha/"), Difficulty = 4</label>
     <cap-widget id="cap" data-cap-api-endpoint="/api/captcha/"></cap-widget>
 
-    <label class="form-label mt-4">Login Type CAPTCHA (data-cap-api-endpoint="/api/captcha/login/") , Difficulty = 5</label>
+    <label class="form-label mt-4">Login Use Case CAPTCHA (data-cap-api-endpoint="/api/captcha/login/") , Difficulty = 5</label>
     <cap-widget id="cap-login" data-cap-api-endpoint="/api/captcha/login/"></cap-widget>
 </div>
 

--- a/samples/AspNetCore3_1/Startup.cs
+++ b/samples/AspNetCore3_1/Startup.cs
@@ -23,7 +23,7 @@ public class Startup
         services.AddRazorPages();
         services.AddPowCapServer(options =>
         {
-            options.TypeConfigs = new Dictionary<string, PowCapConfig>
+            options.UseCaseConfigs = new Dictionary<string, PowCapConfig>
             {
                 ["login"] = new PowCapConfig { ChallengeDifficulty = 5 }
             };

--- a/samples/WebApplication1/Pages/Index.cshtml
+++ b/samples/WebApplication1/Pages/Index.cshtml
@@ -13,7 +13,7 @@
     <label class="form-label">Default CAPTCHA (data-cap-api-endpoint="/api/captcha/"), Difficulty = 4</label>
     <cap-widget id="cap" data-cap-api-endpoint="/api/captcha/"></cap-widget>
 
-    <label class="form-label mt-4">Login Type CAPTCHA (data-cap-api-endpoint="/api/captcha/login/") , Difficulty = 5</label>
+    <label class="form-label mt-4">Login Use Case CAPTCHA (data-cap-api-endpoint="/api/captcha/login/") , Difficulty = 5</label>
     <cap-widget id="cap-login" data-cap-api-endpoint="/api/captcha/login/"></cap-widget>
 </div>
 

--- a/samples/WebApplication1/Program.cs
+++ b/samples/WebApplication1/Program.cs
@@ -7,7 +7,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddRazorPages();
 builder.Services.AddPowCapServer(options =>
 {
-    options.TypeConfigs = new Dictionary<string, PowCapConfig>
+    options.UseCaseConfigs = new Dictionary<string, PowCapConfig>
     {
         ["login"] = new PowCapConfig { ChallengeDifficulty = 5 }
     };

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Copyright>Amos Huang</Copyright>
     <Authors>Amos Huang</Authors>
-    <Version>1.0.3</Version>
+    <Version>1.0.4</Version>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageProjectUrl>https://github.com/izanhzh/pow-cap-server</PackageProjectUrl>

--- a/src/PowCapServer.AspNetCore/Microsoft/AspNetCore/Builder/PowCapServerApplicationBuilderExtensions.cs
+++ b/src/PowCapServer.AspNetCore/Microsoft/AspNetCore/Builder/PowCapServerApplicationBuilderExtensions.cs
@@ -13,9 +13,9 @@ public static class PowCapServerApplicationBuilderExtensions
         {
             var trimmedPrefix = endpointPrefix?.Trim('/');
             var challengeEndpoint = string.IsNullOrEmpty(trimmedPrefix) ? "/challenge" : $"/{trimmedPrefix}/challenge";
-            var challengeEndpointWithType = string.IsNullOrEmpty(trimmedPrefix) ? "/{type}/challenge" : $"/{trimmedPrefix}/{{type}}/challenge";
+            var challengeEndpointWithUseCase = string.IsNullOrEmpty(trimmedPrefix) ? "/{useCase}/challenge" : $"/{trimmedPrefix}/{{useCase}}/challenge";
             var redeemEndpoint = string.IsNullOrEmpty(trimmedPrefix) ? "/redeem" : $"/{trimmedPrefix}/redeem";
-            var redeemEndpointWithType = string.IsNullOrEmpty(trimmedPrefix) ? "/{type}/redeem" : $"/{trimmedPrefix}/{{type}}/redeem";
+            var redeemEndpointWithUseCase = string.IsNullOrEmpty(trimmedPrefix) ? "/{useCase}/redeem" : $"/{trimmedPrefix}/{{useCase}}/redeem";
 
             endpoints.MapPost(challengeEndpoint, async context =>
             {
@@ -25,11 +25,11 @@ public static class PowCapServerApplicationBuilderExtensions
                 await context.Response.WriteAsJsonAsync(challengeTokenInfo).ConfigureAwait(false);
             });
 
-            endpoints.MapPost(challengeEndpointWithType, async context =>
+            endpoints.MapPost(challengeEndpointWithUseCase, async context =>
             {
                 var captchaService = context.RequestServices.GetRequiredService<ICaptchaService>();
-                var type = context.Request.RouteValues["type"]?.ToString();
-                var challengeTokenInfo = await captchaService.CreateChallengeAsync(type).ConfigureAwait(false);
+                var useCase = context.Request.RouteValues["useCase"]?.ToString();
+                var challengeTokenInfo = await captchaService.CreateChallengeAsync(useCase).ConfigureAwait(false);
                 context.Response.ContentType = "application/json";
                 await context.Response.WriteAsJsonAsync(challengeTokenInfo).ConfigureAwait(false);
             });
@@ -50,10 +50,10 @@ public static class PowCapServerApplicationBuilderExtensions
                 await context.Response.WriteAsJsonAsync(result).ConfigureAwait(false);
             });
 
-            endpoints.MapPost(redeemEndpointWithType, async context =>
+            endpoints.MapPost(redeemEndpointWithUseCase, async context =>
             {
                 var captchaService = context.RequestServices.GetRequiredService<ICaptchaService>();
-                var type = context.Request.RouteValues["type"]?.ToString();
+                var useCase = context.Request.RouteValues["useCase"]?.ToString();
                 var request = await context.Request.ReadFromJsonAsync<ChallengeSolution>().ConfigureAwait(false);
                 if (request == null)
                 {
@@ -61,7 +61,7 @@ public static class PowCapServerApplicationBuilderExtensions
                     await context.Response.WriteAsync("Invalid request").ConfigureAwait(false);
                     return;
                 }
-                var result = await captchaService.RedeemChallengeAsync(type, request).ConfigureAwait(false);
+                var result = await captchaService.RedeemChallengeAsync(useCase, request).ConfigureAwait(false);
                 context.Response.ContentType = "application/json";
                 await context.Response.WriteAsJsonAsync(result).ConfigureAwait(false);
             });

--- a/src/PowCapServer.Core/Abstractions/ICaptchaService.cs
+++ b/src/PowCapServer.Core/Abstractions/ICaptchaService.cs
@@ -8,11 +8,11 @@ public interface ICaptchaService
 {
     Task<ChallengeTokenInfo> CreateChallengeAsync(CancellationToken cancellationToken = default);
 
-    Task<ChallengeTokenInfo> CreateChallengeAsync(string? type, CancellationToken cancellationToken = default);
+    Task<ChallengeTokenInfo> CreateChallengeAsync(string? useCase, CancellationToken cancellationToken = default);
 
     Task<RedeemChallengeResult> RedeemChallengeAsync(ChallengeSolution challengeSolution, CancellationToken cancellationToken = default);
 
-    Task<RedeemChallengeResult> RedeemChallengeAsync(string? type, ChallengeSolution challengeSolution, CancellationToken cancellationToken = default);
+    Task<RedeemChallengeResult> RedeemChallengeAsync(string? useCase, ChallengeSolution challengeSolution, CancellationToken cancellationToken = default);
 
     Task<bool> ValidateCaptchaTokenAsync(string captchaToken, CancellationToken cancellationToken = default);
 }

--- a/src/PowCapServer.Core/DefaultCaptchaService.cs
+++ b/src/PowCapServer.Core/DefaultCaptchaService.cs
@@ -27,9 +27,9 @@ public class DefaultCaptchaService : ICaptchaService
         return InternalCreateChallengeAsync(_powCapServerOptions.Value.Default, cancellationToken);
     }
 
-    public virtual Task<ChallengeTokenInfo> CreateChallengeAsync(string? type, CancellationToken cancellationToken = default)
+    public virtual Task<ChallengeTokenInfo> CreateChallengeAsync(string? useCase, CancellationToken cancellationToken = default)
     {
-        return InternalCreateChallengeAsync(_powCapServerOptions.Value.GetPowCapConfig(type), cancellationToken);
+        return InternalCreateChallengeAsync(_powCapServerOptions.Value.GetPowCapConfig(useCase), cancellationToken);
     }
 
     protected virtual async Task<ChallengeTokenInfo> InternalCreateChallengeAsync(PowCapConfig? powCapConfig, CancellationToken cancellationToken = default)
@@ -54,9 +54,9 @@ public class DefaultCaptchaService : ICaptchaService
         return InternalRedeemChallengeAsync(_powCapServerOptions.Value.Default, challengeSolution, cancellationToken);
     }
 
-    public virtual Task<RedeemChallengeResult> RedeemChallengeAsync(string? type, ChallengeSolution challengeSolution, CancellationToken cancellationToken = default)
+    public virtual Task<RedeemChallengeResult> RedeemChallengeAsync(string? useCase, ChallengeSolution challengeSolution, CancellationToken cancellationToken = default)
     {
-        return InternalRedeemChallengeAsync(_powCapServerOptions.Value.GetPowCapConfig(type), challengeSolution, cancellationToken);
+        return InternalRedeemChallengeAsync(_powCapServerOptions.Value.GetPowCapConfig(useCase), challengeSolution, cancellationToken);
     }
 
     protected virtual async Task<RedeemChallengeResult> InternalRedeemChallengeAsync(PowCapConfig? powCapConfig, ChallengeSolution challengeSolution, CancellationToken cancellationToken = default)

--- a/src/PowCapServer.Core/PowCapServerOptions.cs
+++ b/src/PowCapServer.Core/PowCapServerOptions.cs
@@ -5,26 +5,26 @@ namespace PowCapServer;
 public class PowCapServerOptions
 {
     /// <summary>
-    /// Default configuration for not specified PoW Captcha types
+    /// Default configuration for not specified use cases of PoW Captcha.
     /// </summary>
     public PowCapConfig Default { get; set; } = new PowCapConfig();
 
     /// <summary>
-    /// Dictionary of configurations for different types of PoW Captcha
+    /// Dictionary of configurations for different use case of PoW Captcha
     /// </summary>
-    public Dictionary<string, PowCapConfig>? TypeConfigs { get; set; }
+    public Dictionary<string, PowCapConfig>? UseCaseConfigs { get; set; }
 
     /// <summary>
-    /// Gets the configuration for a specific type of PoW Captcha.
+    /// Gets the configuration for a specific use case of PoW Captcha.
     /// </summary>
-    /// <param name="type">The type of PoW Captcha for which the configuration is requested. If null, no specific type is queried.</param>
+    /// <param name="useCase">The use case of PoW Captcha for which the configuration is requested. If null, no specific use case is queried.</param>
     /// <returns>
-    /// Returns the configuration for the specified type if it exists in <see cref="TypeConfigs"/>. 
-    /// Returns null if <see cref="TypeConfigs"/> is null, the specified type is null, or the type is not found in the dictionary.
+    /// Returns the configuration for the specified use case if it exists in <see cref="UseCaseConfigs"/>. 
+    /// Returns null if <see cref="UseCaseConfigs"/> is null, the specified use case is null, or the use case is not found in the dictionary.
     /// </returns>
-    public PowCapConfig GetPowCapConfig(string? type)
+    public PowCapConfig GetPowCapConfig(string? useCase)
     {
-        if (TypeConfigs == null || type == null || !TypeConfigs.TryGetValue(type, out var config))
+        if (UseCaseConfigs == null || useCase == null || !UseCaseConfigs.TryGetValue(useCase, out var config))
         {
             return Default;
         }


### PR DESCRIPTION
This commit renames the 'type' parameter to 'useCase' throughout the codebase to better reflect its purpose. The changes include:

- ASP.NET Core route parameter name changed from 'type' to 'useCase'
- Method parameter names updated from 'type' to 'useCase' 
- Updated corresponding documentation comments
- Maintained backward compatibility for API endpoint usage
- Renamed PowCapServerOptions.TypeConfigs property to UseCaseConfigs
- Updated all references to use the new UseCaseConfigs property

The parameter rename improves code clarity and better represents the intended usage as a use case identifier rather than a simple type.