### PR TITLE
Chore:  use different package version for netstandard2.0

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Copyright>Amos Huang</Copyright>
     <Authors>Amos Huang</Authors>
-    <Version>1.0.4</Version>
+    <Version>1.0.5</Version>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageProjectUrl>https://github.com/izanhzh/pow-cap-server</PackageProjectUrl>

--- a/src/PowCapServer.Core/PowCapServer.Core.csproj
+++ b/src/PowCapServer.Core/PowCapServer.Core.csproj
@@ -4,14 +4,17 @@
     <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup  Condition="'$(TargetFramework)' != 'netstandard2.0'">
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.7" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.7" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.7" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Text.Json" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="3.1.32" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.32" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.32" />
+    <PackageReference Include="System.Text.Json" Version="4.7.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Resolved potential compatibility issues when using newer package versions on the netstandard2.0 framework.