### PR TITLE
Chore: remove unnecessary package references

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Copyright>Amos Huang</Copyright>
     <Authors>Amos Huang</Authors>
-    <Version>1.0.6</Version>
+    <Version>1.0.7</Version>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageProjectUrl>https://github.com/izanhzh/pow-cap-server</PackageProjectUrl>

--- a/src/PowCapServer.Core/Microsoft/Extensions/DependencyInjection/PowCapServerServiceCollectionExtensions.cs
+++ b/src/PowCapServer.Core/Microsoft/Extensions/DependencyInjection/PowCapServerServiceCollectionExtensions.cs
@@ -9,7 +9,6 @@ public static class PowCapServerServiceCollectionExtensions
 {
     public static IServiceCollection AddPowCapServer(this IServiceCollection services, Action<PowCapServerOptions>? options = null)
     {
-        services.AddDistributedMemoryCache();
         services.TryAddSingleton<ICaptchaService, DefaultCaptchaService>();
         services.TryAddSingleton<ICaptchaStore, DefaultCaptchaStore>();
         services.Configure<PowCapServerOptions>(opts => options?.Invoke(opts));

--- a/src/PowCapServer.Core/PowCapServer.Core.csproj
+++ b/src/PowCapServer.Core/PowCapServer.Core.csproj
@@ -7,13 +7,11 @@
   <ItemGroup  Condition="'$(TargetFramework)' != 'netstandard2.0'">
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.7" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.7" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="3.1.32" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.32" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.32" />
     <PackageReference Include="System.Text.Json" Version="4.7.2" />
   </ItemGroup>
 


### PR DESCRIPTION
Microsoft.Extensions.Caching.Memory is already included as part of the ASP.NET Core shared framework through the FrameworkReference to Microsoft.AspNetCore.App. The explicit package reference is redundant and can be safely removed.