### PR TITLE
fix(captcha): bind redeemed tokens to their use case (#20)

### DIFF
--- a/src/PowCapServer.Core/Abstractions/ICaptchaService.cs
+++ b/src/PowCapServer.Core/Abstractions/ICaptchaService.cs
@@ -14,5 +14,21 @@ public interface ICaptchaService
 
     Task<RedeemChallengeResult> RedeemChallengeAsync(string? useCase, ChallengeSolution challengeSolution, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Validate a captcha token without checking which use case it was
+    /// redeemed for. Prefer the <see cref="ValidateCaptchaTokenAsync(string?, string, CancellationToken)"/>
+    /// overload on any endpoint that opts into a non-default use case;
+    /// without the use-case check, a token redeemed under one
+    /// configuration is accepted by every other (issue #20).
+    /// </summary>
     Task<bool> ValidateCaptchaTokenAsync(string captchaToken, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Validate a captcha token and require it to have been redeemed
+    /// under the supplied <paramref name="useCase"/>. Pass
+    /// <c>null</c> to require the default (no-use-case) configuration.
+    /// Tokens whose stored use case does not match are rejected even
+    /// when the token itself is well-formed and unexpired.
+    /// </summary>
+    Task<bool> ValidateCaptchaTokenAsync(string? useCase, string captchaToken, CancellationToken cancellationToken = default);
 }

--- a/src/PowCapServer.Core/DefaultCaptchaService.cs
+++ b/src/PowCapServer.Core/DefaultCaptchaService.cs
@@ -55,15 +55,15 @@ public class DefaultCaptchaService : ICaptchaService
 
     public virtual Task<RedeemChallengeResult> RedeemChallengeAsync(ChallengeSolution challengeSolution, CancellationToken cancellationToken = default)
     {
-        return InternalRedeemChallengeAsync(_powCapServerOptions.Value.Default, challengeSolution, cancellationToken);
+        return InternalRedeemChallengeAsync(_powCapServerOptions.Value.Default, null, challengeSolution, cancellationToken);
     }
 
     public virtual Task<RedeemChallengeResult> RedeemChallengeAsync(string? useCase, ChallengeSolution challengeSolution, CancellationToken cancellationToken = default)
     {
-        return InternalRedeemChallengeAsync(_powCapServerOptions.Value.GetPowCapConfig(useCase), challengeSolution, cancellationToken);
+        return InternalRedeemChallengeAsync(_powCapServerOptions.Value.GetPowCapConfig(useCase), useCase, challengeSolution, cancellationToken);
     }
 
-    protected virtual async Task<RedeemChallengeResult> InternalRedeemChallengeAsync(PowCapConfig? powCapConfig, ChallengeSolution challengeSolution, CancellationToken cancellationToken = default)
+    protected virtual async Task<RedeemChallengeResult> InternalRedeemChallengeAsync(PowCapConfig? powCapConfig, string? useCase, ChallengeSolution challengeSolution, CancellationToken cancellationToken = default)
     {
         powCapConfig ??= _powCapServerOptions.Value.Default;
 
@@ -113,12 +113,25 @@ public class DefaultCaptchaService : ICaptchaService
         var hash = DigestUtil.Sha256Hex(vertoken);
         var id = RandomUtil.ToHexString(RandomUtil.RandomBytes(8));
 
-        await _captchaStore.SaveCaptchaTokenInfoAsync(new CaptchaTokenInfo($"{id}_{hash}", expires), cancellationToken).ConfigureAwait(false);
+        await _captchaStore.SaveCaptchaTokenInfoAsync(new CaptchaTokenInfo($"{id}_{hash}", expires, useCase), cancellationToken).ConfigureAwait(false);
 
         return RedeemChallengeResult.Ok($"{id}_{vertoken}", expires);
     }
 
-    public virtual async Task<bool> ValidateCaptchaTokenAsync(string captchaToken, CancellationToken cancellationToken = default)
+    public virtual Task<bool> ValidateCaptchaTokenAsync(string captchaToken, CancellationToken cancellationToken = default)
+    {
+        // Use-case-blind validation: kept for backwards compatibility.
+        // Issue #20: callers gating sensitive flows should switch to the
+        // use-case-aware overload below.
+        return InternalValidateCaptchaTokenAsync(captchaToken, expectedUseCase: null, enforceUseCase: false, cancellationToken);
+    }
+
+    public virtual Task<bool> ValidateCaptchaTokenAsync(string? useCase, string captchaToken, CancellationToken cancellationToken = default)
+    {
+        return InternalValidateCaptchaTokenAsync(captchaToken, expectedUseCase: useCase, enforceUseCase: true, cancellationToken);
+    }
+
+    protected virtual async Task<bool> InternalValidateCaptchaTokenAsync(string captchaToken, string? expectedUseCase, bool enforceUseCase, CancellationToken cancellationToken)
     {
         await _captchaStore.CleanExpiredTokensAsync(cancellationToken).ConfigureAwait(false);
 
@@ -139,6 +152,16 @@ public class DefaultCaptchaService : ICaptchaService
         }
         if (captchaTokenInfo.Expires < DateTimeOffset.Now.ToUnixTimeMilliseconds())
         {
+            await _captchaStore.DeleteCaptchaTokenInfoAsync(captchaTokenInfo, cancellationToken).ConfigureAwait(false);
+            return false;
+        }
+
+        if (enforceUseCase
+            && !string.Equals(captchaTokenInfo.UseCase, expectedUseCase, StringComparison.Ordinal))
+        {
+            // Token is otherwise valid but was redeemed under a different
+            // use case. Burn it (single-use semantics still apply) and
+            // refuse: pre-#20 the caller would have gotten true here.
             await _captchaStore.DeleteCaptchaTokenInfoAsync(captchaTokenInfo, cancellationToken).ConfigureAwait(false);
             return false;
         }

--- a/src/PowCapServer.Core/Models/CaptchaTokenInfo.cs
+++ b/src/PowCapServer.Core/Models/CaptchaTokenInfo.cs
@@ -7,13 +7,20 @@ public class CaptchaTokenInfo
     {
         Token = string.Empty;
         Expires = 0;
+        UseCase = null;
     }
 #endif
 
     public CaptchaTokenInfo(string token, long expires)
+        : this(token, expires, null)
+    {
+    }
+
+    public CaptchaTokenInfo(string token, long expires, string? useCase)
     {
         Token = token;
         Expires = expires;
+        UseCase = useCase;
     }
 
     /// <summary>
@@ -25,4 +32,15 @@ public class CaptchaTokenInfo
     /// Expiration timestamp
     /// </summary>
     public long Expires { get; set; }
+
+    /// <summary>
+    /// The use case the token was redeemed for. <c>null</c> means the
+    /// token was redeemed under the default (no use case specified)
+    /// configuration. Validation must compare this against the use case
+    /// the consumer is gating on; without that check, a token redeemed
+    /// for a low-friction use case (e.g. <c>contact-us</c>) would pass
+    /// a high-friction one (e.g. <c>register-new-account</c>). See
+    /// issue #20.
+    /// </summary>
+    public string? UseCase { get; set; }
 }

--- a/test/PowCapServer.Test/DefaultCaptchaServiceTests.cs
+++ b/test/PowCapServer.Test/DefaultCaptchaServiceTests.cs
@@ -123,11 +123,100 @@ public class DefaultCaptchaServiceTests
         Assert.False(secondUse); // token was consumed
     }
 
+    // --- Issue #20: use-case scoping ---
+
+    [Fact]
+    public async Task ValidateCaptchaTokenAsync_WithMatchingUseCase_ReturnsTrue()
+    {
+        var challengeToken = await StoreValidChallengeAsync(challengeCount: 0, token: "uc_match_token");
+        var redeemResult = await _service.RedeemChallengeAsync("login", new ChallengeSolution(challengeToken, new List<int>()));
+        Assert.True(redeemResult.Success);
+
+        var ok = await _service.ValidateCaptchaTokenAsync("login", redeemResult.Token!);
+
+        Assert.True(ok);
+    }
+
+    [Fact]
+    public async Task ValidateCaptchaTokenAsync_WithDifferentUseCase_ReturnsFalse()
+    {
+        // Token redeemed under low-friction "form" use case must not validate
+        // for a high-friction "login" use case (issue #20).
+        var challengeToken = await StoreValidChallengeAsync(challengeCount: 0, token: "uc_xuse_token");
+        var redeemResult = await _service.RedeemChallengeAsync("form", new ChallengeSolution(challengeToken, new List<int>()));
+        Assert.True(redeemResult.Success);
+
+        var ok = await _service.ValidateCaptchaTokenAsync("login", redeemResult.Token!);
+
+        Assert.False(ok);
+    }
+
+    [Fact]
+    public async Task ValidateCaptchaTokenAsync_DefaultUseCaseDoesNotMatchExplicitUseCase()
+    {
+        // Token redeemed under no use case (default config) must not validate
+        // when the caller is gating on an explicit use case.
+        var challengeToken = await StoreValidChallengeAsync(challengeCount: 0, token: "uc_default_token");
+        var redeemResult = await _service.RedeemChallengeAsync(new ChallengeSolution(challengeToken, new List<int>()));
+        Assert.True(redeemResult.Success);
+
+        var ok = await _service.ValidateCaptchaTokenAsync("login", redeemResult.Token!);
+
+        Assert.False(ok);
+    }
+
+    [Fact]
+    public async Task ValidateCaptchaTokenAsync_DefaultUseCaseMatchesNullUseCaseOverload()
+    {
+        // The use-case-aware overload with null requires the token to have
+        // been redeemed under the default (no use case) configuration.
+        var challengeToken = await StoreValidChallengeAsync(challengeCount: 0, token: "uc_default_match_token");
+        var redeemResult = await _service.RedeemChallengeAsync(new ChallengeSolution(challengeToken, new List<int>()));
+        Assert.True(redeemResult.Success);
+
+        var ok = await _service.ValidateCaptchaTokenAsync(useCase: null, redeemResult.Token!);
+
+        Assert.True(ok);
+    }
+
+    [Fact]
+    public async Task ValidateCaptchaTokenAsync_LegacyOverloadStaysUseCaseBlind()
+    {
+        // The original ValidateCaptchaTokenAsync(token) overload retains its
+        // pre-#20 behavior so existing consumers that haven't yet adopted
+        // the use-case-aware overload continue to work.
+        var challengeToken = await StoreValidChallengeAsync(challengeCount: 0, token: "uc_legacy_token");
+        var redeemResult = await _service.RedeemChallengeAsync("form", new ChallengeSolution(challengeToken, new List<int>()));
+        Assert.True(redeemResult.Success);
+
+        var ok = await _service.ValidateCaptchaTokenAsync(redeemResult.Token!);
+
+        Assert.True(ok);
+    }
+
+    [Fact]
+    public async Task ValidateCaptchaTokenAsync_UseCaseMismatchStillBurnsToken()
+    {
+        // A use-case mismatch must still consume the token (single-use
+        // semantics), so an attacker can't probe it against multiple
+        // use cases until they find a match.
+        var challengeToken = await StoreValidChallengeAsync(challengeCount: 0, token: "uc_burn_token");
+        var redeemResult = await _service.RedeemChallengeAsync("form", new ChallengeSolution(challengeToken, new List<int>()));
+        Assert.True(redeemResult.Success);
+
+        var firstWrong = await _service.ValidateCaptchaTokenAsync("login", redeemResult.Token!);
+        Assert.False(firstWrong);
+
+        // Even though the token was originally good for the "form" use case,
+        // the mismatched probe consumed it.
+        var secondCorrect = await _service.ValidateCaptchaTokenAsync("form", redeemResult.Token!);
+        Assert.False(secondCorrect);
+    }
+
     // --- Helpers ---
 
-    private async Task<string> StoreValidChallengeAsync(int challengeCount)
+    private async Task<string> StoreValidChallengeAsync(int challengeCount, string token = "test_challenge_token")
     {
-        const string token = "test_challenge_token";
         var info = new ChallengeTokenInfo(
             new Challenge(challengeCount, 32, 1),
             token,


### PR DESCRIPTION
Closes #20.

`ICaptchaService.ValidateCaptchaTokenAsync(token)` was use-case-blind: a CAPTCHA token redeemed under a low-friction use case (e.g. `contact-us`) was accepted by every other endpoint that called the shared validation API, including high-friction ones the server owner deliberately scoped (`register-new-account`, `login`, etc.).

## Changes

- `CaptchaTokenInfo` carries a nullable `UseCase` field. `null` means the token was redeemed under the default (no use-case specified) configuration; a non-null value records the `UseCaseConfigs` key the redeem was issued under.
- `RedeemChallengeAsync(useCase?, …)` propagates the supplied use case through `InternalRedeemChallengeAsync` into the saved `CaptchaTokenInfo`. The no-use-case `RedeemChallengeAsync(…)` overload stores `null`, matching prior behavior.
- `ICaptchaService` gains a new `ValidateCaptchaTokenAsync(string? useCase, string captchaToken, CancellationToken)` overload. It rejects tokens whose stored `UseCase` doesn't equal the supplied one (ordinal compare; both sides nullable). The token is still consumed on a use-case mismatch so an attacker can't probe a single redeemed token against multiple use cases.
- The original `ValidateCaptchaTokenAsync(captchaToken, …)` overload stays use-case-blind for backwards compatibility, with an XML-doc note recommending callers gating sensitive flows switch to the new overload.

## Tests

Six new tests pin the contract:

1. matching use case → true
2. cross-use-case mismatch → false (canonical issue scenario)
3. default-redeemed token vs explicit-use-case validate → false
4. default-redeemed token via `null`-use-case overload → true
5. legacy overload still use-case-blind (backwards compat)
6. mismatched probe still burns the token

## Test plan

- [x] `dotnet build pow-cap-server.sln` — clean across netstandard2.0 / net8.0 / net9.0 / net10.0
- [x] `dotnet test pow-cap-server.sln` — 28/28 pass (22 prior + 6 new)